### PR TITLE
Bug Fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,14 +1,18 @@
 Changelog
 =========
 
-0.0.4 (2018-12-20)
+0.2.1 (2019-01-30)
 -----------------------------------------
-* Initial load into GitHub
+- Bug Fix - Create points along lines now correctly saves the lines to shapefile.
+
+0.2.0 (2019-01-24)
+-----------------------------------------
+* New Feature - Create points for a strip trial along a central line and offset left and right at distance.
 
 0.1.1 (2019-01-22)
 -----------------------------------------
 * New Feature - Create zones using k-means clustering
 
-0.2.0 (2019-01-24)
+0.0.4 (2018-12-20)
 -----------------------------------------
-* New Feature - Create points for a strip trial along a central line and offset left and right at distance.
+* Initial load into GitHub

--- a/pyprecag/processing.py
+++ b/pyprecag/processing.py
@@ -1901,7 +1901,7 @@ def create_points_along_line(lines_geodataframe, lines_crs, distance_between_poi
             save_geopandas_tofile(gdf_lines, out_lines_shapefile, overwrite=True)
 
     if out_points_shapefile is not None or config.get_debug_mode():
-        if out_lines_shapefile is None:
+        if out_points_shapefile is None:
             save_geopandas_tofile(gdf_points, temp_filename.replace('.shp', '_points.shp'), overwrite=True)
         else:
             save_geopandas_tofile(gdf_points, out_points_shapefile, overwrite=True)

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         'future',
         'fiona',
         'gdal', # Required Microsoft Visual C++ Compiler for Python 2.7
-        'rasterio', # Required Numpy
+        'rasterio>1,<=1.0.13', # Required Numpy
         # These were included to prevent import errors:
         'geopandas',
         'unidecode',


### PR DESCRIPTION
- Restrict  pyprecag to rasterio v1.0.13 (#12)
- Create points along lines now correctly saves the lines to shapefile.