### PR TITLE
Fix pip upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ notebooks/
 .vscode/
 Pipfile
 Pipfile.lock
+.python-version

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help:
 	echo '  * upload-test: uploads a test version to https://test.pypi.org/project/pyprecag'
 
 .PHONY: twine_check
-twine_check: sdist
+twine_check: sdist bdist_wheel
 	twine check ./dist/*
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ help:
 	echo '  * develop: installs pyprecag in development mode.'
 	echo '  * uninstall: removes the development package from pip.'
 	echo '  * test: runs all unit tests.'
+	echo '  * twine_check: Run `twine check`.'
 	echo '  * lint: runs pylint.'
 	echo '  * html: builds the HTML documentation.'
 	echo '  * pdf: builds the documentation in PDF format.'
@@ -24,6 +25,10 @@ help:
 	echo '  * bdist_wheel: builds a universal wheel distribution.'
 	echo '  * upload: uploads the source distribution and wheels to PyPI'
 	echo '  * upload-test: uploads a test version to https://test.pypi.org/project/pyprecag'
+
+.PHONY: twine_check
+twine_check: sdist
+	twine check ./dist/*
 
 .PHONY: test
 test:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,14 @@ here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the relevant file
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
-    long_description = f.read()
+    # Twine and PyPI don't seem to like include directives, so do as GitHub does
+    # and strip them out of the long_description. They are still used to build the
+    # more comprehensive Sphinx documentation.
+    filtered_lines = []
+    for line in f:
+        if line.find('.. include') != 0:
+            filtered_lines.append(line)
+    long_description = ''.join(filtered_lines)
 
 setup(
     name='pyprecag',

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     version='0.3.0',
     description='A suite of tools for Precision Agriculture',
     long_description=long_description,
+    long_description_content_type='text/x-rst',
 
     # The project's main homepage.
     url='https://github.com/CSIRO-Precision-Agriculture/pyprecag',


### PR DESCRIPTION
Inspired by how GitHub strips the `.. include` directives from the README.rst rendering, I added code to do the same thing when loading the README.rst into the long_description field.